### PR TITLE
Fix several allowances with same keys

### DIFF
--- a/lib/nimble_ownership.ex
+++ b/lib/nimble_ownership.ex
@@ -627,6 +627,11 @@ defmodule NimbleOwnership do
   defp fix_resolved({_, [], _}, state), do: state
 
   defp fix_resolved({allowances, _fun_to_pids, lazy_calls}, state) do
-    %__MODULE__{state | allowances: Map.new(allowances), lazy_calls: lazy_calls}
+    allowances =
+      Enum.reduce(allowances, %{}, fn {k, v}, acc ->
+        Map.update(acc, k, v, &Map.merge(&1, v))
+      end)
+
+    %__MODULE__{state | allowances: allowances, lazy_calls: lazy_calls}
   end
 end

--- a/test/nimble_ownership_test.exs
+++ b/test/nimble_ownership_test.exs
@@ -274,8 +274,8 @@ defmodule NimbleOwnershipTest do
       {:ok, pid_1} = Task.start_link(parent_process_fun.(1))
       {:ok, pid_2} = Task.start_link(parent_process_fun.(2))
 
-      lazy_process_fun = fn f ->
-        fn ->
+      lazy_process_fun = fn ->
+        for _ <- 1..2 do
           receive do
             {:go, parent_pid, key} ->
               assert {:ok, owner_pid} = NimbleOwnership.fetch_owner(@server, [parent_pid], key)
@@ -287,12 +287,11 @@ defmodule NimbleOwnershipTest do
               end)
 
               send(parent_pid, :done)
-              f.(f).()
           end
         end
       end
 
-      {:ok, lazy_pid} = Task.start_link(lazy_process_fun.(lazy_process_fun))
+      {:ok, lazy_pid} = Task.start_link(lazy_process_fun)
       Process.register(lazy_pid, :lazy_pid)
 
       send(pid_1, {:go, lazy_pid})


### PR DESCRIPTION
In `mox` (including but not limited to the latest version,) when one adds several deferred mocks to the list of allowed processes, this results in the following `allowances` passed to the private `fix_resolved/2`

```elixir
[
  {#PID<0.237.0>, %{MyMod1.Mox => #PID<0.221.0>}},
  {#PID<0.237.0>, %{MyMod2.Mox => #PID<0.221.0>}}
]
```
and gets effectively ruined by `Map.new/1` into
```elixir
%{#PID<0.237.0> => %{MyMod2.Mox => #PID<0.221.0>}}
```
This PR provides a proper map construction from a proplist above by merging maps.

---

The test could have been done better, please guide me if you want it to be prettified.

Thanks!