### PR TITLE
Accept a list of pids from deferred allowance function

### DIFF
--- a/lib/nimble_ownership.ex
+++ b/lib/nimble_ownership.ex
@@ -171,7 +171,8 @@ defmodule NimbleOwnership do
 
   """
   @spec allow(server(), pid(), pid() | (-> resolved_pid), key()) ::
-          :ok | {:error, Error.t()} when resolved_pid: pid() | [pid()]
+          :ok | {:error, Error.t()}
+        when resolved_pid: pid() | [pid()]
   def allow(ownership_server, pid_with_access, pid_to_allow, key, timeout \\ 5000)
       when is_pid(pid_with_access) and (is_pid(pid_to_allow) or is_function(pid_to_allow, 0)) and
              is_timeout(timeout) do

--- a/lib/nimble_ownership.ex
+++ b/lib/nimble_ownership.ex
@@ -153,10 +153,10 @@ defmodule NimbleOwnership do
 
   If the process is not yet started at the moment of allowance definition, it might be allowed
   as a function, assuming at the moment of invocation it would have been started.
-  If the function cannot be resolved to a pid during invocation, the expectation will not succeed.
+  If the function cannot be resolved to a PID during invocation, the expectation will not succeed.
 
-  The function might return a `t:pid/0` or a list of `t:pid/0`s, the latter might be helpful
-  if one needs to allow a pool of unnamed workers.
+  The function might return a `t:pid/0` or a list of `t:pid/0`s. A list might be helpful
+  if one needs to allow multiple PIDs that resolve from a single term, such as the list of workers in a pool.
 
   ## Examples
 
@@ -170,8 +170,8 @@ defmodule NimbleOwnership do
       {:ok, self()}
 
   """
-  @spec allow(server(), pid(), pid() | (-> pid()) | (-> [pid()]), key()) ::
-          :ok | {:error, Error.t()}
+  @spec allow(server(), pid(), pid() | (-> resolved_pid)), key()) ::
+          :ok | {:error, Error.t()} when resolved_pid: pid() | [pids()]
   def allow(ownership_server, pid_with_access, pid_to_allow, key, timeout \\ 5000)
       when is_pid(pid_with_access) and (is_pid(pid_to_allow) or is_function(pid_to_allow, 0)) and
              is_timeout(timeout) do

--- a/lib/nimble_ownership.ex
+++ b/lib/nimble_ownership.ex
@@ -170,7 +170,7 @@ defmodule NimbleOwnership do
       {:ok, self()}
 
   """
-  @spec allow(server(), pid(), pid() | (-> resolved_pid)), key()) ::
+  @spec allow(server(), pid(), pid() | (-> resolved_pid), key()) ::
           :ok | {:error, Error.t()} when resolved_pid: pid() | [pid()]
   def allow(ownership_server, pid_with_access, pid_to_allow, key, timeout \\ 5000)
       when is_pid(pid_with_access) and (is_pid(pid_to_allow) or is_function(pid_to_allow, 0)) and

--- a/lib/nimble_ownership.ex
+++ b/lib/nimble_ownership.ex
@@ -171,7 +171,7 @@ defmodule NimbleOwnership do
 
   """
   @spec allow(server(), pid(), pid() | (-> resolved_pid)), key()) ::
-          :ok | {:error, Error.t()} when resolved_pid: pid() | [pids()]
+          :ok | {:error, Error.t()} when resolved_pid: pid() | [pid()]
   def allow(ownership_server, pid_with_access, pid_to_allow, key, timeout \\ 5000)
       when is_pid(pid_with_access) and (is_pid(pid_to_allow) or is_function(pid_to_allow, 0)) and
              is_timeout(timeout) do

--- a/lib/nimble_ownership.ex
+++ b/lib/nimble_ownership.ex
@@ -149,6 +149,15 @@ defmodule NimbleOwnership do
   with the owner. If `pid_with_access` terminates, `pid_to_allow` will still have access to the
   key, until the `owner_pid` itself terminates or removes the allowance.
 
+  ### Deferred (lazy) allowances
+
+  If the process is not yet started at the moment of allowance definition, it might be allowed
+  as a function, assuming at the moment of invocation it would have been started.
+  If the function cannot be resolved to a pid during invocation, the expectation will not succeed.
+
+  The function might return a `t:pid/0` or a list of `t:pid/0`s, the latter might be helpful
+  if one needs to allow a pool of unnamed workers.
+
   ## Examples
 
       iex> pid = spawn(fn -> Process.sleep(:infinity) end)
@@ -161,7 +170,7 @@ defmodule NimbleOwnership do
       {:ok, self()}
 
   """
-  @spec allow(server(), pid(), pid() | (-> pid()), key()) ::
+  @spec allow(server(), pid(), pid() | (-> pid()) | (-> [pid()]), key()) ::
           :ok | {:error, Error.t()}
   def allow(ownership_server, pid_with_access, pid_to_allow, key, timeout \\ 5000)
       when is_pid(pid_with_access) and (is_pid(pid_to_allow) or is_function(pid_to_allow, 0)) and
@@ -610,18 +619,37 @@ defmodule NimbleOwnership do
     state.allowances
     |> Enum.reduce({[], [], false}, fn
       {key, value}, {result, resolved, unresolved} when is_function(key, 0) ->
-        case key.() do
-          pid when is_pid(pid) ->
-            {[{pid, value} | result], [{key, pid} | resolved], unresolved}
-
-          _ ->
-            {[{key, value} | result], resolved, true}
-        end
+        resolve_once(key.(), {key, value}, {result, resolved, unresolved})
 
       kv, {result, resolved, unresolved} ->
         {[kv | result], resolved, unresolved}
     end)
     |> fix_resolved(state)
+  end
+
+  defp resolve_once(pid, {key, value}, {result, resolved, unresolved}) when is_pid(pid) do
+    {[{pid, value} | result], [{key, pid} | resolved], unresolved}
+  end
+
+  defp resolve_once([pid | pids], {key, value}, {result, resolved, unresolved})
+       when is_pid(pid) do
+    resolve_once(
+      pids,
+      {key, value},
+      {[{pid, value} | result], [{key, pid} | resolved], unresolved}
+    )
+  end
+
+  defp resolve_once([_not_a_pid | pids], kv, {result, resolved, _unresolved}) do
+    resolve_once(pids, kv, {[kv | result], resolved, true})
+  end
+
+  defp resolve_once([], _kv, {result, resolved, unresolved}) do
+    {result, resolved, unresolved}
+  end
+
+  defp resolve_once(_, kv, {result, resolved, _unresolved}) do
+    {[kv | result], resolved, true}
   end
 
   defp fix_resolved({_, [], _}, state), do: state

--- a/test/nimble_ownership_test.exs
+++ b/test/nimble_ownership_test.exs
@@ -248,7 +248,9 @@ defmodule NimbleOwnershipTest do
                NimbleOwnership.allow(
                  @server,
                  self(),
-                 fn -> [Process.whereis(:lazy_pid_1), Process.whereis(:lazy_pid_2)] end,
+                 fn ->
+                   [Process.whereis(:lazy_pid_1), :not_a_pid, Process.whereis(:lazy_pid_2)]
+                 end,
                  key
                )
 


### PR DESCRIPTION
When working with pools of anonymous workers, one might want to allow all the workers from the whole pool. Again, it mostly makes sense in test environment.

Unfortunately, there is no way to call `allow/5` subsequently (as we do with a straightforward, non-deferred calls) because the workers can be resolved as a whole list within the context of the deferred call only.

To satisfy the aforementioned requirement (the _contrived_ use-case might be found [here](https://stackoverflow.com/questions/78785326/getting-the-pid-from-flame-call-2) although I understand it’s not the normal way of doing it, but still, pools are widely used and the ability to allow all workers looks natural to me,) this PR proposes the function to lazy resolve the allowances to be permitted to return lists of pids.

```diff
-  @spec allow(server(), pid(), pid() | (-> pid()), key()) ::
           :ok | {:error, Error.t()}
+  @spec allow(server(), pid(), pid() | (-> pid()) | (-> [pid()]), key()) ::
           :ok | {:error, Error.t()}

```