### PR TITLE
Only resolve lazy allowances if absolutely necessary

### DIFF
--- a/lib/nimble_ownership.ex
+++ b/lib/nimble_ownership.ex
@@ -405,10 +405,7 @@ defmodule NimbleOwnership do
     allowances: %{},
 
     # This is used to track which PIDs we're monitoring, to avoid double-monitoring.
-    monitored_pids: MapSet.new(),
-
-    # This boolean field tracks whether there are any lazy calls in the allowances.
-    lazy_calls: false
+    monitored_pids: MapSet.new()
   ]
 
   ## Callbacks
@@ -468,15 +465,12 @@ defmodule NimbleOwnership do
           state
           |> maybe_monitor_pid(pid_with_access)
           |> put_in([Access.key!(:allowances), Access.key(pid_to_allow, %{}), key], owner_pid)
-          |> update_in([Access.key!(:lazy_calls)], &(&1 or is_function(pid_to_allow, 0)))
 
         {:reply, :ok, state}
     end
   end
 
   def handle_call({:get_and_update, owner_pid, key, fun}, _from, %__MODULE__{} = state) do
-    state = revalidate_lazy_calls(state)
-
     case state.mode do
       {:shared, shared_owner_pid} when shared_owner_pid != owner_pid ->
         error = %Error{key: key, reason: {:not_shared_owner, shared_owner_pid}}
@@ -485,6 +479,8 @@ defmodule NimbleOwnership do
       _ ->
         :ok
     end
+
+    state = resolve_lazy_calls_for_key(state, key)
 
     if other_owner = state.allowances[owner_pid][key] do
       throw({:reply, {:error, %Error{key: key, reason: {:already_allowed, other_owner}}}, state})
@@ -526,15 +522,15 @@ defmodule NimbleOwnership do
   end
 
   def handle_call({:fetch_owner, callers, key}, _from, %__MODULE__{mode: :private} = state) do
-    state = revalidate_lazy_calls(state)
-
-    Enum.find_value(callers, {:reply, :error, state}, fn caller ->
-      case state do
-        %{allowances: %{^caller => %{^key => owner_pid}}} -> {:reply, {:ok, owner_pid}, state}
-        %{owners: %{^caller => %{^key => _meta}}} -> {:reply, {:ok, caller}, state}
-        _ -> nil
-      end
-    end)
+    with nil <- fetch_owner_once(state, callers, key) do
+      state = resolve_lazy_calls_for_key(state, key)
+      {fetch_owner_once(state, callers, key), state}
+    end
+    |> case do
+      {nil, new_state} -> {:reply, :error, new_state}
+      {found, new_state} -> {:reply, {:ok, found}, new_state}
+      found -> {:reply, {:ok, found}, state}
+    end
   end
 
   def handle_call({:get_owned, owner_pid, default}, _from, %__MODULE__{} = state) do
@@ -616,51 +612,39 @@ defmodule NimbleOwnership do
     end
   end
 
-  defp revalidate_lazy_calls(state) do
-    state.allowances
-    |> Enum.reduce({[], [], false}, fn
-      {key, value}, {result, resolved, unresolved} when is_function(key, 0) ->
-        resolve_once(key.(), {key, value}, {result, resolved, unresolved})
-
-      kv, {result, resolved, unresolved} ->
-        {[kv | result], resolved, unresolved}
+  defp fetch_owner_once(state, callers, key) do
+    Enum.find_value(callers, fn caller ->
+      case state do
+        %{owners: %{^caller => %{^key => _meta}}} -> caller
+        %{allowances: %{^caller => %{^key => owner_pid}}} -> owner_pid
+        _ -> nil
+      end
     end)
-    |> fix_resolved(state)
   end
 
-  defp resolve_once(pid, {key, value}, {result, resolved, unresolved}) when is_pid(pid) do
-    {[{pid, value} | result], [{key, pid} | resolved], unresolved}
-  end
+  defp resolve_lazy_calls_for_key(state, key) do
+    updated_allowances =
+      state.allowances
+      |> Enum.reduce(state.allowances, fn
+        {fun, value}, allowances when is_function(fun, 0) and is_map_key(value, key) ->
+          result =
+            fun.()
+            |> List.wrap()
+            |> Enum.group_by(&is_pid/1)
 
-  defp resolve_once([pid | pids], {key, value}, {result, resolved, unresolved})
-       when is_pid(pid) do
-    resolve_once(
-      pids,
-      {key, value},
-      {[{pid, value} | result], [{key, pid} | resolved], unresolved}
-    )
-  end
+          allowances =
+            result
+            |> Map.get(true, [])
+            |> Enum.reduce(allowances, fn pid, allowances ->
+              Map.update(allowances, pid, value, &Map.merge(&1, value))
+            end)
 
-  defp resolve_once([_not_a_pid | pids], kv, {result, resolved, _unresolved}) do
-    resolve_once(pids, kv, {[kv | result], resolved, true})
-  end
+          if Map.has_key?(allowances, false), do: Map.delete(allowances, fun), else: allowances
 
-  defp resolve_once([], _kv, {result, resolved, unresolved}) do
-    {result, resolved, unresolved}
-  end
-
-  defp resolve_once(_, kv, {result, resolved, _unresolved}) do
-    {[kv | result], resolved, true}
-  end
-
-  defp fix_resolved({_, [], _}, state), do: state
-
-  defp fix_resolved({allowances, _fun_to_pids, lazy_calls}, state) do
-    allowances =
-      Enum.reduce(allowances, %{}, fn {k, v}, acc ->
-        Map.update(acc, k, v, &Map.merge(&1, v))
+        _, allowances ->
+          allowances
       end)
 
-    %__MODULE__{state | allowances: allowances, lazy_calls: lazy_calls}
+    %{state | allowances: updated_allowances}
   end
 end


### PR DESCRIPTION
I've recently ran into weird Mox failures while running a lot of asynchronous tests that leverage lazy allowances resolution. After some investigation, I figured that `NimbleOwnership` resolves _all_ lazy allowances every time `get_and_update` or `fetch_owner` is called. Given that Mox runs a single global server, this results in a situation when a lazy allowance can be resolved at a random time simply because another tests was making a call to a different mock. 

<details>

<summary>Here's a failing Mox test for example</summary>

```elixir
    test "allowances support lazy calls for asynchronous tests" do
      defmodule CalculatorServer_Lazy do
        use GenServer

        def init(args) do
          {:ok, args}
        end

        def handle_call(:call_mock, _from, []) do
          add_result = CalcMock.add(1, 1)
          {:reply, add_result, []}
        end
      end

      {:ok, _} = Registry.start_link(keys: :unique, name: Registry.Test)
      real_name = {:via, Registry, {Registry.Test, :test_process_lazy}}
      fake_name = {:via, Registry, {FakeRegistry, :test_process_lazy}}

      CalcMock
      |> expect(:add, fn _, _ -> :expected end)
      |> allow(self(), fn -> GenServer.whereis(real_name) end)
      
      FakeMock
      |> allow(self(), fn -> GenServer.whereis(fake_name) end)

      {:ok, _} = GenServer.start_link(CalculatorServer_Lazy, [], name: real_name)
      add_result = GenServer.call(real_name, :call_mock)
      assert add_result == :expected
    end
```

```
1) test allow/3 allowances support lazy calls for asynchronous tests (MoxTest)
     test/mox_test.exs:1035
     ** (EXIT from #PID<0.295.0>) exited in: GenServer.call({:global, Mox.Server}, {:fetch_owner, [#PID<0.301.0>], CalcMock}, 30000)
         ** (EXIT) an exception was raised:
             ** (ArgumentError) unknown registry: FakeRegistry
                 (elixir 1.17.3) lib/registry.ex:1400: Registry.key_info!/1
                 (elixir 1.17.3) lib/registry.ex:237: Registry.whereis_name/2
                 (elixir 1.17.3) lib/gen_server.ex:1300: GenServer.whereis/1
                 (nimble_ownership 1.0.0) lib/nimble_ownership.ex:623: anonymous fn/2 in NimbleOwnership.revalidate_lazy_calls/1
                 (stdlib 6.1) maps.erl:860: :maps.fold_1/4
                 (nimble_ownership 1.0.0) lib/nimble_ownership.ex:621: NimbleOwnership.revalidate_lazy_calls/1
                 (nimble_ownership 1.0.0) lib/nimble_ownership.ex:529: NimbleOwnership.handle_call/3
                 (stdlib 6.1) gen_server.erl:2381: :gen_server.try_handle_call/4
                 (stdlib 6.1) gen_server.erl:2410: :gen_server.handle_msg/6
                 (stdlib 6.1) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
```

</details>

This PR aims to address this:

Changes:
1. I removed `lazy_calls` from the state. I don't believe it was actually _read_ anywhere.
2. Replace `revalidate_lazy_calls/2` with `resolve_lazy_calls_for_key/2`. It will only resolve allowances for the given key.
3. Reshuffle `fetch_owner` code a little so that we would first attempt all owners and resolved allowances and only if nothing worked resolve lazy ones.

Notes:
* I did my best to maintain `resolve_lazy_calls_for_key`'s behaviour in a sense that it allows callbacks to "keep on giving". That means that resolution is never final and [this check](https://github.com/dashbitco/nimble_ownership/blob/48ee44133daf61587b74635de8a6257b9e23aebe/lib/nimble_ownership.ex#L489-L491) is not bullet-proof and a process _can_ become an owner of a key it has allowance for. I'm not sure what the implications of this are though 😅 
* This doesn't fully address my Mox issue, as operations on the same mock can still trigger other test's allowance resolution too early, but it should be less likely.