### PR TITLE
Correctly fetch owners if metadata is falsey

### DIFF
--- a/lib/nimble_ownership.ex
+++ b/lib/nimble_ownership.ex
@@ -529,10 +529,10 @@ defmodule NimbleOwnership do
     state = revalidate_lazy_calls(state)
 
     Enum.find_value(callers, {:reply, :error, state}, fn caller ->
-      cond do
-        owner_pid = state.allowances[caller][key] -> {:reply, {:ok, owner_pid}, state}
-        _meta = state.owners[caller][key] -> {:reply, {:ok, caller}, state}
-        true -> nil
+      case state do
+        %{allowances: %{^caller => %{^key => owner_pid}}} -> {:reply, {:ok, owner_pid}, state}
+        %{owners: %{^caller => %{^key => _meta}}} -> {:reply, {:ok, caller}, state}
+        _ -> nil
       end
     end)
   end

--- a/test/nimble_ownership_test.exs
+++ b/test/nimble_ownership_test.exs
@@ -32,6 +32,17 @@ defmodule NimbleOwnershipTest do
       assert owner_pid == self()
     end
 
+    test "nil as metadata is ok", %{key: key} do
+      assert {:ok, nil} =
+               NimbleOwnership.get_and_update(@server, self(), key, fn arg ->
+                 assert arg == nil
+                 {nil, arg}
+               end)
+
+      assert {:ok, owner_pid} = NimbleOwnership.fetch_owner(@server, [self()], key)
+      assert owner_pid == self()
+    end
+
     test "updates the metadata with the returned value from the function", %{key: key} do
       test_pid = self()
       init_key(test_pid, key, %{counter: 1})


### PR DESCRIPTION
Currently, it is impossible to fetch owner if stored metadata is falsey:

```elixir
iex(1)> {:ok, pid} = NimbleOwnership.start_link(name: Server)
{:ok, #PID<0.199.0>}
iex(2)> {:ok, nil} = NimbleOwnership.get_and_update(Server, self(), :foo, fn metadata -> {nil, metadata} end)
{:ok, nil}
iex(3)> NimbleOwnership.fetch_owner(Server, [self()], :foo)
:error
```

The PR fixes it by replacing chained map access in `cond` with matching `case`.